### PR TITLE
feat: add Filament 5 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to `filament-emoji-picker` will be documented in this file.
 
+## 3.0.0 - 2026-03-24
+
+- Add Filament v5 support (thanks to @GeleVla)
+- **Breaking:** requires Filament 5, PHP 8.2+, Laravel 11.28+ (and Livewire 4 as required by Filament). Stay on `^2.0` of this package for Filament 4 apps.
+
 ## 2.0.0 - 2025-12-11
 
 - Add Filament v4 support (thanks to @alessandrobelli)

--- a/README.md
+++ b/README.md
@@ -11,6 +11,9 @@ Add an emoji picker to your Filament input fields.
 | --- | --- |
 | 3.x | 1.x |
 | 4.x | 2.x |
+| 5.x | 3.x |
+
+Use `composer require tangodev-it/filament-emoji-picker:^3.0` on Filament 5, or `^2.0` if you are still on Filament 4.
 
 ## Installation
 
@@ -38,7 +41,7 @@ Publish the config file if you want to change the default language of the picker
 
 Just add the `EmojiPickerAction` to your existing input fields and you're ready to go 🚀.
 
-Never heard about form actions? [Read more](https://filamentphp.com/docs/3.x/forms/actions).
+Never heard about forms? [Read more](https://filamentphp.com/docs/5.x/forms/overview).
 
 ```php
 use TangoDevIt\FilamentEmojiPicker\EmojiPickerAction;
@@ -84,10 +87,10 @@ TextInput::make('title')
 You can attach the `EmojiPickerAction` also to a `Textarea` field:
 
 ```php
-Textarea::make('messagge')
+Textarea::make('message')
     ->required()
     ->maxLength(255)
-    ->hintAction(EmojiPickerAction::make('emoji-messagge')),
+    ->hintAction(EmojiPickerAction::make('emoji-message')),
 ```
 
 <img src="https://github.com/TangoDev-it/filament-emoji-picker/raw/main/screenshots/textarea_hint_action.png" width="600">
@@ -158,7 +161,7 @@ return [
 ];
 ```
 
-For further informations please refer to the [underlying javascript library documentation](https://github.com/nolanlawson/emoji-picker-element/?tab=readme-ov-file#internationalization).
+For further information please refer to the [underlying javascript library documentation](https://github.com/nolanlawson/emoji-picker-element/?tab=readme-ov-file#internationalization).
 
 ## Theming
 
@@ -179,13 +182,13 @@ Please see [CONTRIBUTING](.github/CONTRIBUTING.md) for details.
 
 ## Security Vulnerabilities
 
-Please review [our security policy](../../security/policy) on how to report security vulnerabilities.
+Please review [our security policy](https://github.com/TangoDev-it/filament-emoji-picker/security/policy) on how to report security vulnerabilities.
 
 ## Credits
 
 - [emoji-picker-element](https://github.com/nolanlawson/emoji-picker-element)
 - [TangoDev](https://github.com/TangoDev-it)
-- [All Contributors](../../contributors)
+- [All Contributors](https://github.com/TangoDev-it/filament-emoji-picker/graphs/contributors)
 
 ## License
 

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     ],
     "require": {
         "php": "^8.2",
-        "filament/filament": "^4.0",
+        "filament/filament": "^5.0",
         "spatie/laravel-package-tools": "^1.15.0"
     },
     "require-dev": {

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -9,13 +9,13 @@ use Filament\FilamentServiceProvider;
 use Filament\Forms\FormsServiceProvider;
 use Filament\Infolists\InfolistsServiceProvider;
 use Filament\Notifications\NotificationsServiceProvider;
+use Filament\Schemas\SchemasServiceProvider;
 use Filament\Support\SupportServiceProvider;
 use Filament\Tables\TablesServiceProvider;
 use Filament\Widgets\WidgetsServiceProvider;
 use Illuminate\Database\Eloquent\Factories\Factory;
 use Livewire\LivewireServiceProvider;
 use Orchestra\Testbench\TestCase as Orchestra;
-use RyanChandler\BladeCaptureDirective\BladeCaptureDirectiveServiceProvider;
 use TangoDevIt\FilamentEmojiPicker\FilamentEmojiPickerServiceProvider;
 
 class TestCase extends Orchestra
@@ -25,7 +25,7 @@ class TestCase extends Orchestra
         parent::setUp();
 
         Factory::guessFactoryNamesUsing(
-            fn (string $modelName) => 'TangoDevIt\\FilamentEmojiPicker\\Database\\Factories\\' . class_basename($modelName) . 'Factory'
+            fn(string $modelName) => 'TangoDevIt\\FilamentEmojiPicker\\Database\\Factories\\' . class_basename($modelName) . 'Factory'
         );
     }
 
@@ -33,10 +33,10 @@ class TestCase extends Orchestra
     {
         return [
             ActionsServiceProvider::class,
-            BladeCaptureDirectiveServiceProvider::class,
             BladeHeroiconsServiceProvider::class,
             BladeIconsServiceProvider::class,
             FilamentServiceProvider::class,
+            SchemasServiceProvider::class,
             FormsServiceProvider::class,
             InfolistsServiceProvider::class,
             LivewireServiceProvider::class,


### PR DESCRIPTION
Adds Filament 5 compatibility by updating the version constraint in composer.json.

  Changes:
  - composer.json: "filament/filament": "^4.0" → "filament/filament": "^4.0 || ^5.0"

  Tested on Filament 5 with Laravel 12 / PHP 8.4.